### PR TITLE
added docker development environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM ubuntu:latest
+
+# Set the the maximum size of core files created to unlimited
 RUN ulimit -c unlimited
+
+# Install development dependencies
 RUN apt-get update
 RUN apt-get install -y \
     build-essential \
@@ -11,5 +15,16 @@ RUN apt-get install -y \
     libasound2-dev \
     gdb \
     gdbserver
+
+# Download and install the ARM GCC toolkit for linux Version 7-2018-q2-update
+ADD https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-rm/7-2018q2/gcc-arm-none-eabi-7-2018-q2-update-linux.tar.bz2 /tmp/gcc-arm-none-eabi-7-2018-q2-update-linux.tar.bz2
+RUN mkdir -p /usr/local/share/arm
+RUN tar -C /usr/local/share/arm -xjf /tmp/gcc-arm-none-eabi-7-2018-q2-update-linux.tar.bz2
+RUN (cd /usr/local/share/arm/gcc-arm-none-eabi-7-2018-q2-update/bin/ && \
+    for x in *; do \
+        ln -s /usr/local/share/arm/gcc-arm-none-eabi-7-2018-q2-update/bin/$x /usr/local/bin/$x; \
+    done)
+
+# Create the workspace and set it as the workdir.  This is where the local volume should be mounted
 RUN mkdir -p /workspace
 WORKDIR /workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu:latest
+RUN ulimit -c unlimited
+RUN apt-get update
+RUN apt-get install -y \
+    build-essential \
+    pkg-config \
+    xorg \
+    libx11-dev \
+    libxmu-dev \
+    libgtk2.0-dev \
+    libasound2-dev \
+    gdb \
+    gdbserver
+RUN mkdir -p /workspace
+WORKDIR /workspace

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+build:
+	docker run -v $(PWD):/workspace -e DISPLAY=host.docker.internal:0 free42 make -C gtk -e BCD_MATH=1 AUDIO_ALSA=1
+
+clean:
+	make -C gtk cleaner
+
+dev-build:
+	docker build -t free42:latest .
+
+dev:
+	docker run -itv $(PWD):/workspace -e DISPLAY=host.docker.internal:0 free42
+
+run: build
+	docker run -v $(PWD):/workspace -e DISPLAY=host.docker.internal:0 free42 gtk/free42dec
+
+debug: build
+	docker run -itv $(PWD):/workspace -e DISPLAY=host.docker.internal:0 free42 gdb gtk/free42dec
+
+remote-debug: build
+	docker run -p 9001:9001 -itv $(PWD):/workspace -e DISPLAY=host.docker.internal:0 free42 gdbserver :9001 gtk/free42dec
+
+.PHONY: build clean dev-build dev run debug remote-debug

--- a/gtk/Makefile
+++ b/gtk/Makefile
@@ -35,7 +35,7 @@ CXXFLAGS = $(CFLAGS) \
 	 -D_WCHAR_T_DEFINED
 
 LDFLAGS = -L/usr/X11R6/lib
-LIBS = gcc111libbid.a -lXmu -lX11 $(shell pkg-config --libs gtk+-2.0)
+LIBS = gcc111libbid.a -lXmu -lX11 $(shell pkg-config --libs gtk+-2.0) -ldl
 
 ifeq "$(shell uname -s)" "Linux"
 LDFLAGS += -Wl,--hash-style=both


### PR DESCRIPTION
This work adds a developer environment which was setup via docker for
compiling, debugging, and running across different systems.  By default, the run
and debug make targets will have the internal x display pointed to the
host's :0 display.  The dev target can be used to launch the docker
container in interactive mode.